### PR TITLE
Use jemalloc for Rust on Linux

### DIFF
--- a/.changelog/42.feature
+++ b/.changelog/42.feature
@@ -1,0 +1,1 @@
+Switched to using jemalloc on Linux (for the memory tracking code only), which should deal better both in terms of memory usage and speed with many small allocations.

--- a/.changelog/42.feature
+++ b/.changelog/42.feature
@@ -1,1 +1,2 @@
-Switched to using jemalloc on Linux (for the memory tracking code only), which should deal better both in terms of memory usage and speed with many small allocations.
+Switched to using jemalloc on Linux, which should deal better both in terms of memory usage and speed with many small allocations.
+It also simplifies the code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +109,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fnv"
 version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fs_extra"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -161,6 +171,25 @@ dependencies = [
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -256,6 +285,7 @@ dependencies = [
  "im 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "inferno 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -569,18 +599,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitmaps 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81e039a80914325b37fde728ef7693c212f0ac913d5599607d7b95a9484aae0b"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+"checksum cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum const-random 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
 "checksum const-random-macro 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum im 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e302bf26ba21de289e808230f80fe799fd371268d853783ee7f844c7cb5704b7"
 "checksum inferno 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2a71c56e4c218f2a1d36bc5177cbfdedf89697ac68610ac3c8452cde152231"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+"checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -38,6 +38,7 @@ extern void *_rjem_calloc(size_t nmemb, size_t length);
 extern void *_rjem_realloc(void *addr, size_t length);
 extern void _rjem_free(void *addr);
 extern void *_rjem_aligned_alloc(size_t alignment, size_t size);
+extern size_t _rjem_malloc_usable_size(void *ptr);
 
 // Note whether we've been initialized yet or not:
 static int initialized = 0;
@@ -300,6 +301,14 @@ SYMBOL_PREFIX(aligned_alloc)(size_t alignment, size_t size) {
   }
   return result;
 }
+
+#ifdef __linux__
+// Make sure we expose jemalloc variant of malloc_usable_size(), in case someone
+// actually uses it.
+size_t SYMBOL_PREFIX(malloc_usable_size)(void *ptr) {
+  return REAL_IMPL(malloc_usable_size)(ptr);
+}
+#endif
 
 #ifdef __APPLE__
 DYLD_INTERPOSE(SYMBOL_PREFIX(malloc), malloc)

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -341,7 +341,7 @@ fil_tracer(PyObject *obj, PyFrameObject *frame, int what, PyObject *arg) {
       // Ensure the two string never get garbage collected;
       Py_INCREF(frame->f_code->co_filename);
       Py_INCREF(frame->f_code->co_name);
-      loc = _rjem_malloc(sizeof(struct FunctionLocation));
+      loc = REAL_IMPL(malloc)(sizeof(struct FunctionLocation));
       loc->filename = PyUnicode_AsUTF8AndSize(frame->f_code->co_filename,
                                               &loc->filename_length);
       loc->function_name = PyUnicode_AsUTF8AndSize(frame->f_code->co_name,

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -32,7 +32,7 @@ static void *(*underlying_real_mmap)(void *addr, size_t length, int prot,
                                      int flags, int fd, off_t offset) = 0;
 static int (*underlying_real_munmap)(void *addr, size_t length) = 0;
 
-// Used on Linux to initialize Rust code's jemalloc:
+// Used on Linux to implement these APIs:
 extern void *_rjem_malloc(size_t length);
 extern void *_rjem_calloc(size_t nmemb, size_t length);
 extern void *_rjem_realloc(void *addr, size_t length);

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -128,6 +128,13 @@ static void __attribute__((constructor)) constructor() {
   unsetenv("LD_PRELOAD");
   // This seems to break things... revisit at some point.
   // unsetenv("DYLD_INSERT_LIBRARIES");
+
+  // malloc() triggers Rust code triggers memory allocation, ensuring jemalloc
+  // is initialized as early as possible. If jemalloc is initialized via
+  // mmap() -> Rust -> allocation, it deadlocks because jemalloc uses mmap to
+  // get more memory!
+  //malloc(1);
+  printf("WHAT\n");
 }
 
 // Implemented in the Rust library:

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -204,7 +204,7 @@ static void add_anon_mmap(size_t address, size_t size) {
 __attribute__((visibility("default"))) void *
 SYMBOL_PREFIX(malloc)(size_t size) {
   void *result = REAL_IMPL(malloc)(size);
-  if (!am_i_reentrant()) {
+  if (initialized && !am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     add_allocation((size_t)result, size);
     set_will_i_be_reentrant(0);
@@ -216,7 +216,7 @@ __attribute__((visibility("default"))) void *
 SYMBOL_PREFIX(calloc)(size_t nmemb, size_t size) {
   void *result = REAL_IMPL(calloc)(nmemb, size);
   size_t allocated = nmemb * size;
-  if (!am_i_reentrant()) {
+  if (initialized && !am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     add_allocation((size_t)result, allocated);
     set_will_i_be_reentrant(0);
@@ -227,7 +227,7 @@ SYMBOL_PREFIX(calloc)(size_t nmemb, size_t size) {
 __attribute__((visibility("default"))) void *
 SYMBOL_PREFIX(realloc)(void *addr, size_t size) {
   void *result = REAL_IMPL(realloc)(addr, size);
-  if (!am_i_reentrant()) {
+  if (initialized && !am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     // Sometimes you'll get same address, so if we did remove first and then
     // added, it would remove the entry erroneously.
@@ -240,7 +240,7 @@ SYMBOL_PREFIX(realloc)(void *addr, size_t size) {
 
 __attribute__((visibility("default"))) void SYMBOL_PREFIX(free)(void *addr) {
   REAL_IMPL(free)(addr);
-  if (!am_i_reentrant()) {
+  if (initialized && !am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     pymemprofile_free_allocation((size_t)addr);
     set_will_i_be_reentrant(0);
@@ -293,7 +293,7 @@ SYMBOL_PREFIX(aligned_alloc)(size_t alignment, size_t size) {
   void *result = REAL_IMPL(aligned_alloc)(alignment, size);
 
   // For now we only track anonymous mmap()s:
-  if (!am_i_reentrant()) {
+  if (initialized && !am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     add_allocation((size_t)result, size);
     set_will_i_be_reentrant(0);

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -155,7 +155,8 @@ extern void pymemprofile_add_anon_mmap(size_t address, size_t length,
                                        uint16_t line_number);
 extern void pymemprofile_free_anon_mmap(size_t address, size_t length);
 
-void start_call(struct FunctionLocation *loc, uint16_t line_number) {
+static void
+start_call(struct FunctionLocation *loc, uint16_t line_number) {
   if (!am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     uint16_t parent_line_number = 0;
@@ -168,7 +169,7 @@ void start_call(struct FunctionLocation *loc, uint16_t line_number) {
   }
 }
 
-void finish_call() {
+static void finish_call() {
   if (!am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     pymemprofile_finish_call();

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -10,28 +10,34 @@
 #include <stdio.h>
 #include <sys/mman.h>
 
+// Macro to create the publicly exposed symbol:
 #ifdef __APPLE__
 #define SYMBOL_PREFIX(func) reimplemented_##func
 #else
 #define SYMBOL_PREFIX(func) func
 #endif
 
+// Macro to get the underlying function being wrapped:
+#ifdef __APPLE__
+#define REAL_IMPL(func) func
+#elif __linux__
+#define REAL_IMPL(func) _rjem_##func
+#endif
+
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
 
 // Underlying APIs we're wrapping:
-static void *(*underlying_real_malloc)(size_t length) = 0;
-static void *(*underlying_real_calloc)(size_t nmemb, size_t length) = 0;
-static void *(*underlying_real_realloc)(void *addr, size_t length) = 0;
-static void (*underlying_real_free)(void *addr) = 0;
 static void *(*underlying_real_mmap)(void *addr, size_t length, int prot,
                                      int flags, int fd, off_t offset) = 0;
 static int (*underlying_real_munmap)(void *addr, size_t length) = 0;
-static void *(*underlying_real_aligned_alloc)(size_t alignment,
-                                              size_t size) = 0;
 
 // Used on Linux to initialize Rust code's jemalloc:
 extern void *_rjem_malloc(size_t length);
+extern void *_rjem_calloc(size_t nmemb, size_t length);
+extern void *_rjem_realloc(void *addr, size_t length);
+extern void _rjem_free(void *addr);
+extern void *_rjem_aligned_alloc(size_t alignment, size_t size);
 
 // Note whether we've been initialized yet or not:
 static int initialized = 0;
@@ -57,7 +63,7 @@ static inline uint64_t am_i_reentrant() {
 static inline void set_will_i_be_reentrant(uint64_t i) {
   pthread_setspecific(will_i_be_reentrant, (void *)i);
 }
-#else
+#elif __linux__
 #include <sys/syscall.h>
 static _Thread_local int will_i_be_reentrant = 0;
 
@@ -93,26 +99,7 @@ static void __attribute__((constructor)) constructor() {
     fprintf(stderr, "BUG: expected size of size_t and void* to be the same.\n");
     exit(1);
   }
-  underlying_real_malloc = dlsym(RTLD_NEXT, "malloc");
-  if (!underlying_real_malloc) {
-    fprintf(stderr, "Couldn't load malloc(): %s\n", dlerror());
-    exit(1);
-  }
-  underlying_real_calloc = dlsym(RTLD_NEXT, "calloc");
-  if (!underlying_real_calloc) {
-    fprintf(stderr, "Couldn't load calloc(): %s\n", dlerror());
-    exit(1);
-  }
-  underlying_real_realloc = dlsym(RTLD_NEXT, "realloc");
-  if (!underlying_real_realloc) {
-    fprintf(stderr, "Couldn't load realloc(): %s\n", dlerror());
-    exit(1);
-  }
-  underlying_real_free = dlsym(RTLD_NEXT, "free");
-  if (!underlying_real_free) {
-    fprintf(stderr, "Couldn't load free(): %s\n", dlerror());
-    exit(1);
-  }
+
   underlying_real_mmap = dlsym(RTLD_NEXT, "mmap");
   if (!underlying_real_mmap) {
     fprintf(stderr, "Couldn't load mmap(): %s\n", dlerror());
@@ -123,16 +110,6 @@ static void __attribute__((constructor)) constructor() {
     fprintf(stderr, "Couldn't load munmap(): %s\n", dlerror());
     exit(1);
   }
-
-  // Older macOS don't have aligned_alloc... but therefore presumably also won't
-  // call it.
-#ifndef __APPLE__
-  underlying_real_aligned_alloc = dlsym(RTLD_NEXT, "aligned_alloc");
-  if (!underlying_real_aligned_alloc) {
-    fprintf(stderr, "Couldn't load aligned_alloc(): %s\n", dlerror());
-    exit(1);
-  }
-#endif
 
   initialized = 1;
   unsetenv("LD_PRELOAD");
@@ -155,8 +132,7 @@ extern void pymemprofile_add_anon_mmap(size_t address, size_t length,
                                        uint16_t line_number);
 extern void pymemprofile_free_anon_mmap(size_t address, size_t length);
 
-static void
-start_call(struct FunctionLocation *loc, uint16_t line_number) {
+static void start_call(struct FunctionLocation *loc, uint16_t line_number) {
   if (!am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     uint16_t parent_line_number = 0;
@@ -224,30 +200,11 @@ static void add_anon_mmap(size_t address, size_t size) {
   pymemprofile_add_anon_mmap(address, size, line_number);
 }
 
-// On Linux, before the shared library is initialized it's not possible to call
-// malloc() and friends, because the function pointers haven't been loaded with
-// dlsym(). So we need a fallback. On macOS we can just use the function
-// directly, because we're not publishing our own malloc() symbol so we don't
-// get infinite recursion, we can just call the original function.
-static void *malloc_fallback(size_t size) {
-#ifdef __APPLE__
-  return malloc(size);
-#else
-  // We can't use mmap() libc call, because we override it, so use the syscall
-  // directly:
-  return (void *)syscall(SYS_mmap, NULL, size, PROT_READ | PROT_WRITE,
-                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-#endif
-}
-
 // Override memory-allocation functions:
 __attribute__((visibility("default"))) void *
 SYMBOL_PREFIX(malloc)(size_t size) {
-  if (unlikely(!initialized)) {
-    return malloc_fallback(size);
-  }
-  void *result = underlying_real_malloc(size);
-  if (!am_i_reentrant() && initialized) {
+  void *result = REAL_IMPL(malloc)(size);
+  if (!am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     add_allocation((size_t)result, size);
     set_will_i_be_reentrant(0);
@@ -257,14 +214,9 @@ SYMBOL_PREFIX(malloc)(size_t size) {
 
 __attribute__((visibility("default"))) void *
 SYMBOL_PREFIX(calloc)(size_t nmemb, size_t size) {
-  if (unlikely(!initialized)) {
-    void* result = malloc_fallback(nmemb * size);
-    memset(result, 0, nmemb * size);
-    return result;
-  }
-  void *result = underlying_real_calloc(nmemb, size);
+  void *result = REAL_IMPL(calloc)(nmemb, size);
   size_t allocated = nmemb * size;
-  if (!am_i_reentrant() && initialized) {
+  if (!am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     add_allocation((size_t)result, allocated);
     set_will_i_be_reentrant(0);
@@ -274,21 +226,8 @@ SYMBOL_PREFIX(calloc)(size_t nmemb, size_t size) {
 
 __attribute__((visibility("default"))) void *
 SYMBOL_PREFIX(realloc)(void *addr, size_t size) {
-  if (unlikely(!initialized)) {
-#ifdef __APPLE__
-    return realloc(addr, size);
-#else
-    void *result = malloc_fallback(size);
-    if (addr != NULL) {
-      // Why someone should realloc() with null pointer I don't know.
-      // But they sometimes do.
-      memcpy(result, addr, size);
-    }
-    return result;
-#endif
-  }
-  void *result = underlying_real_realloc(addr, size);
-  if (!am_i_reentrant() && initialized) {
+  void *result = REAL_IMPL(realloc)(addr, size);
+  if (!am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     // Sometimes you'll get same address, so if we did remove first and then
     // added, it would remove the entry erroneously.
@@ -300,15 +239,7 @@ SYMBOL_PREFIX(realloc)(void *addr, size_t size) {
 }
 
 __attribute__((visibility("default"))) void SYMBOL_PREFIX(free)(void *addr) {
-  if (unlikely(!initialized)) {
-#ifdef __APPLE__
-    free(addr);
-#else
-// We're going to leak a little memory, but, such is life...
-#endif
-    return;
-  }
-  underlying_real_free(addr);
+  REAL_IMPL(free)(addr);
   if (!am_i_reentrant()) {
     set_will_i_be_reentrant(1);
     pymemprofile_free_allocation((size_t)addr);
@@ -323,7 +254,7 @@ SYMBOL_PREFIX(mmap)(void *addr, size_t length, int prot, int flags, int fd,
 #ifdef __APPLE__
     return mmap(addr, length, prot, flags, fd, offset);
 #else
-    return (void*) syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+    return (void *)syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
 #endif
   }
 
@@ -359,23 +290,7 @@ SYMBOL_PREFIX(munmap)(void *addr, size_t length) {
 
 __attribute__((visibility("default"))) void *
 SYMBOL_PREFIX(aligned_alloc)(size_t alignment, size_t size) {
-  if (unlikely(!initialized)) {
-#ifdef __APPLE__
-    return aligned_alloc(alignment, size);
-#else
-    // NOTE: At the moment this falls back to mmap(), so that's fine, but if we
-    // stop using mmap() as fallback we need to switch this to something that
-    // ensures alignment. See
-    // https://github.com/pythonspeed/filprofiler/issues/33
-    return malloc_fallback(size);
-#endif
-  }
-
-#ifdef __APPLE__
-  void *result = aligned_alloc(alignment, size);
-#else
-  void *result = underlying_real_aligned_alloc(alignment, size);
-#endif
+  void *result = REAL_IMPL(aligned_alloc)(alignment, size);
 
   // For now we only track anonymous mmap()s:
   if (!am_i_reentrant()) {
@@ -426,7 +341,7 @@ fil_tracer(PyObject *obj, PyFrameObject *frame, int what, PyObject *arg) {
       // Ensure the two string never get garbage collected;
       Py_INCREF(frame->f_code->co_filename);
       Py_INCREF(frame->f_code->co_name);
-      loc = underlying_real_malloc(sizeof(struct FunctionLocation));
+      loc = _rjem_malloc(sizeof(struct FunctionLocation));
       loc->filename = PyUnicode_AsUTF8AndSize(frame->f_code->co_filename,
                                               &loc->filename_length);
       loc->function_name = PyUnicode_AsUTF8AndSize(frame->f_code->co_name,

--- a/filprofiler/_script.py
+++ b/filprofiler/_script.py
@@ -66,14 +66,17 @@ def stage_1():
     # Route all allocations from Python through malloc() directly:
     environ["PYTHONMALLOC"] = "malloc"
     # Disable multi-threaded backends in various scientific computing libraries
-    # (Zarr uses Blosc, NumPy uses BLAS):
+    # (Zarr uses Blosc, NumPy uses BLAS, OpenMP is generically used):
     environ["BLOSC_NTHREADS"] = "1"
     environ["OMP_NUM_THREADS"] = "1"
     environ["OPENBLAS_NUM_THREADS"] = "1"
     environ["MKL_NUM_THREADS"] = "1"
     environ["VECLIB_MAXIMUM_THREADS"] = "1"
     environ["NUMEXPR_NUM_THREADS"] = "1"
-
+    # Tell jemalloc code (if used) to clean up faster:
+    environ[
+        "_RJEM_MALLOC_CONF"
+    ] = "dirty_decay_ms:100,muzzy_decay_ms:1000,abort_conf:true"
     execv(
         sys.executable, [sys.executable, "-m", "filprofiler._script"] + sys.argv[1:],
     )

--- a/filprofiler/licenses.txt
+++ b/filprofiler/licenses.txt
@@ -2544,6 +2544,246 @@ The pymemprofile_api package uses some third party libraries under their own lic
     limitations under the License.
 
 
+ * jemalloc-sys 0.3.2 under the terms of MIT / Apache-2.0:
+
+
+    ===============
+
+
+
+ * jemallocator 0.3.2 under the terms of MIT / Apache-2.0:
+
+    Copyright (c) 2014 Alex Crichton
+    
+    Permission is hereby granted, free of charge, to any
+    person obtaining a copy of this software and associated
+    documentation files (the "Software"), to deal in the
+    Software without restriction, including without
+    limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software
+    is furnished to do so, subject to the following
+    conditions:
+    
+    The above copyright notice and this permission notice
+    shall be included in all copies or substantial portions
+    of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+    PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+    SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+    IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    ===============
+
+                                  Apache License
+                            Version 2.0, January 2004
+                         http://www.apache.org/licenses/
+    
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+    
+    1. Definitions.
+    
+       "License" shall mean the terms and conditions for use, reproduction,
+       and distribution as defined by Sections 1 through 9 of this document.
+    
+       "Licensor" shall mean the copyright owner or entity authorized by
+       the copyright owner that is granting the License.
+    
+       "Legal Entity" shall mean the union of the acting entity and all
+       other entities that control, are controlled by, or are under common
+       control with that entity. For the purposes of this definition,
+       "control" means (i) the power, direct or indirect, to cause the
+       direction or management of such entity, whether by contract or
+       otherwise, or (ii) ownership of fifty percent (50%) or more of the
+       outstanding shares, or (iii) beneficial ownership of such entity.
+    
+       "You" (or "Your") shall mean an individual or Legal Entity
+       exercising permissions granted by this License.
+    
+       "Source" form shall mean the preferred form for making modifications,
+       including but not limited to software source code, documentation
+       source, and configuration files.
+    
+       "Object" form shall mean any form resulting from mechanical
+       transformation or translation of a Source form, including but
+       not limited to compiled object code, generated documentation,
+       and conversions to other media types.
+    
+       "Work" shall mean the work of authorship, whether in Source or
+       Object form, made available under the License, as indicated by a
+       copyright notice that is included in or attached to the work
+       (an example is provided in the Appendix below).
+    
+       "Derivative Works" shall mean any work, whether in Source or Object
+       form, that is based on (or derived from) the Work and for which the
+       editorial revisions, annotations, elaborations, or other modifications
+       represent, as a whole, an original work of authorship. For the purposes
+       of this License, Derivative Works shall not include works that remain
+       separable from, or merely link (or bind by name) to the interfaces of,
+       the Work and Derivative Works thereof.
+    
+       "Contribution" shall mean any work of authorship, including
+       the original version of the Work and any modifications or additions
+       to that Work or Derivative Works thereof, that is intentionally
+       submitted to Licensor for inclusion in the Work by the copyright owner
+       or by an individual or Legal Entity authorized to submit on behalf of
+       the copyright owner. For the purposes of this definition, "submitted"
+       means any form of electronic, verbal, or written communication sent
+       to the Licensor or its representatives, including but not limited to
+       communication on electronic mailing lists, source code control systems,
+       and issue tracking systems that are managed by, or on behalf of, the
+       Licensor for the purpose of discussing and improving the Work, but
+       excluding communication that is conspicuously marked or otherwise
+       designated in writing by the copyright owner as "Not a Contribution."
+    
+       "Contributor" shall mean Licensor and any individual or Legal Entity
+       on behalf of whom a Contribution has been received by Licensor and
+       subsequently incorporated within the Work.
+    
+    2. Grant of Copyright License. Subject to the terms and conditions of
+       this License, each Contributor hereby grants to You a perpetual,
+       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+       copyright license to reproduce, prepare Derivative Works of,
+       publicly display, publicly perform, sublicense, and distribute the
+       Work and such Derivative Works in Source or Object form.
+    
+    3. Grant of Patent License. Subject to the terms and conditions of
+       this License, each Contributor hereby grants to You a perpetual,
+       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+       (except as stated in this section) patent license to make, have made,
+       use, offer to sell, sell, import, and otherwise transfer the Work,
+       where such license applies only to those patent claims licensable
+       by such Contributor that are necessarily infringed by their
+       Contribution(s) alone or by combination of their Contribution(s)
+       with the Work to which such Contribution(s) was submitted. If You
+       institute patent litigation against any entity (including a
+       cross-claim or counterclaim in a lawsuit) alleging that the Work
+       or a Contribution incorporated within the Work constitutes direct
+       or contributory patent infringement, then any patent licenses
+       granted to You under this License for that Work shall terminate
+       as of the date such litigation is filed.
+    
+    4. Redistribution. You may reproduce and distribute copies of the
+       Work or Derivative Works thereof in any medium, with or without
+       modifications, and in Source or Object form, provided that You
+       meet the following conditions:
+    
+       (a) You must give any other recipients of the Work or
+           Derivative Works a copy of this License; and
+    
+       (b) You must cause any modified files to carry prominent notices
+           stating that You changed the files; and
+    
+       (c) You must retain, in the Source form of any Derivative Works
+           that You distribute, all copyright, patent, trademark, and
+           attribution notices from the Source form of the Work,
+           excluding those notices that do not pertain to any part of
+           the Derivative Works; and
+    
+       (d) If the Work includes a "NOTICE" text file as part of its
+           distribution, then any Derivative Works that You distribute must
+           include a readable copy of the attribution notices contained
+           within such NOTICE file, excluding those notices that do not
+           pertain to any part of the Derivative Works, in at least one
+           of the following places: within a NOTICE text file distributed
+           as part of the Derivative Works; within the Source form or
+           documentation, if provided along with the Derivative Works; or,
+           within a display generated by the Derivative Works, if and
+           wherever such third-party notices normally appear. The contents
+           of the NOTICE file are for informational purposes only and
+           do not modify the License. You may add Your own attribution
+           notices within Derivative Works that You distribute, alongside
+           or as an addendum to the NOTICE text from the Work, provided
+           that such additional attribution notices cannot be construed
+           as modifying the License.
+    
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+    
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+       any Contribution intentionally submitted for inclusion in the Work
+       by You to the Licensor shall be under the terms and conditions of
+       this License, without any additional terms or conditions.
+       Notwithstanding the above, nothing herein shall supersede or modify
+       the terms of any separate license agreement you may have executed
+       with Licensor regarding such Contributions.
+    
+    6. Trademarks. This License does not grant permission to use the trade
+       names, trademarks, service marks, or product names of the Licensor,
+       except as required for reasonable and customary use in describing the
+       origin of the Work and reproducing the content of the NOTICE file.
+    
+    7. Disclaimer of Warranty. Unless required by applicable law or
+       agreed to in writing, Licensor provides the Work (and each
+       Contributor provides its Contributions) on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+       implied, including, without limitation, any warranties or conditions
+       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+       PARTICULAR PURPOSE. You are solely responsible for determining the
+       appropriateness of using or redistributing the Work and assume any
+       risks associated with Your exercise of permissions under this License.
+    
+    8. Limitation of Liability. In no event and under no legal theory,
+       whether in tort (including negligence), contract, or otherwise,
+       unless required by applicable law (such as deliberate and grossly
+       negligent acts) or agreed to in writing, shall any Contributor be
+       liable to You for damages, including any direct, indirect, special,
+       incidental, or consequential damages of any character arising as a
+       result of this License or out of the use or inability to use the
+       Work (including but not limited to damages for loss of goodwill,
+       work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses), even if such Contributor
+       has been advised of the possibility of such damages.
+    
+    9. Accepting Warranty or Additional Liability. While redistributing
+       the Work or Derivative Works thereof, You may choose to offer,
+       and charge a fee for, acceptance of support, warranty, indemnity,
+       or other liability obligations and/or rights consistent with this
+       License. However, in accepting such obligations, You may act only
+       on Your own behalf and on Your sole responsibility, not on behalf
+       of any other Contributor, and only if You agree to indemnify,
+       defend, and hold each Contributor harmless for any liability
+       incurred by, or claims asserted against, such Contributor by reason
+       of your accepting any such warranty or additional liability.
+    
+    END OF TERMS AND CONDITIONS
+    
+    APPENDIX: How to apply the Apache License to your work.
+    
+       To apply the Apache License to your work, attach the following
+       boilerplate notice, with the fields enclosed by brackets "[]"
+       replaced with your own identifying information. (Don't include
+       the brackets!)  The text should be enclosed in the appropriate
+       comment syntax for the file format. We also recommend that a
+       file or class name and description of purpose be included on the
+       same "printed page" as the copyright notice for easier
+       identification within third-party archives.
+    
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+    	http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
  * lazy_static 1.4.0 under the terms of MIT / Apache-2.0:
 
     Copyright (c) 2010 The Rust Project Developers

--- a/memapi/Cargo.toml
+++ b/memapi/Cargo.toml
@@ -14,6 +14,9 @@ itertools = "0.8.2"
 lazy_static = "1.4.0"
 rustc-hash = "1.0.1"
 
+[target.'cfg(target_os = "linux")'.dependencies.jemallocator]
+version = "0.3.2"
+
 [dependencies.inferno]
 version = "0.9.9"
 default-features = false

--- a/memapi/src/lib.rs
+++ b/memapi/src/lib.rs
@@ -4,6 +4,13 @@ use std::os::raw::c_char;
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(target_os = "linux")]
+use jemallocator::Jemalloc;
+
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 mod memorytracking;
 mod rangemap;
 

--- a/wheels/build-wheels.sh
+++ b/wheels/build-wheels.sh
@@ -18,7 +18,7 @@ rm -rf build
 
 /opt/python/cp38-cp38/bin/python3 setup.py bdist_wheel -d /tmp/wheel
 
-auditwheel repair --plat manylinux1_x86_64 -w dist/ /tmp/wheel/filprofiler*cp36*whl
-auditwheel repair --plat manylinux1_x86_64 -w dist/ /tmp/wheel/filprofiler*cp37*whl
-auditwheel repair --plat manylinux1_x86_64 -w dist/ /tmp/wheel/filprofiler*cp38*whl
+auditwheel repair --plat manylinux2010_x86_64 -w dist/ /tmp/wheel/filprofiler*cp36*whl
+auditwheel repair --plat manylinux2010_x86_64 -w dist/ /tmp/wheel/filprofiler*cp37*whl
+auditwheel repair --plat manylinux2010_x86_64 -w dist/ /tmp/wheel/filprofiler*cp38*whl
 


### PR DESCRIPTION
* [x] Use jemalloc for rust code on Linux.
* [x] Decide whether to use jemalloc for all code on Linux (via measurement).
* [x] Wrap `malloc_usable_size()`.
* [x] Tests pass.

Fixes #42.
Fixes #35.