### PR TITLE
Better warnings (and less breakage) when running subprocesses

### DIFF
--- a/.changelog/117.bugfix
+++ b/.changelog/117.bugfix
@@ -1,0 +1,1 @@
+Fil now works better with subprocessses. It doesn't support memory tracking in subprocesses yet, but it doesn't break them either.

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -315,7 +315,7 @@ static void add_anon_mmap(size_t address, size_t size) {
 
 // Disable memory tracking after fork() in the child.
 __attribute__((visibility("default"))) pid_t SYMBOL_PREFIX(fork)(void) {
-  fprintf(stderr, "=fil-profile= WARNING: Fil does not (yet) support tracking subprocesses.\n");
+  fprintf(stderr, "=fil-profile= WARNING: Fil does not (yet) support tracking memory in subprocesses.\n");
   pid_t result = underlying_real_fork();
   if (result == 0) {
     // We're the child.

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -165,6 +165,11 @@ static void __attribute__((constructor)) constructor() {
   // to ensure we don't get unpleasant reentrancy issues.
   pymemprofile_reset("/tmp");
 
+  // Drop LD_PRELOAD and DYLD_INSERT_LIBRARIES so that subprocesses don't have
+  // this preloaded.
+  unsetenv("LD_PRELOAD");
+  unsetenv("DYLD_INSERT_LIBRARIES");
+  
   initialized = 1;
 }
 
@@ -282,7 +287,6 @@ fil_dump_peak_to_flamegraph(const char *path) {
 }
 
 // *** End APIs called by Python ***
-
 static void add_allocation(size_t address, size_t size) {
   uint16_t line_number = 0;
   PyFrameObject *f = current_frame;

--- a/filprofiler/_script.py
+++ b/filprofiler/_script.py
@@ -126,7 +126,6 @@ def stage_1():
             print(f.read())
     else:
         # Normal operation, via LD_PRELOAD or equivalent:
-        ld_preload = environ.get("LD_PRELOAD")
         environ["LD_PRELOAD"] = library_path("_filpreload")
         environ["DYLD_INSERT_LIBRARIES"] = library_path("_filpreload")
         execve(sys.executable, [sys.executable] + args, env=environ)
@@ -163,8 +162,6 @@ def stage_2():
 
     Presumes LD_PRELOAD etc. has been set by stage_1().
     """
-    if not environ.get("FIL_BENCHMARK") and environ.get("LD_PRELOAD"):
-        del environ["LD_PRELOAD"]
     arguments = PARSER.parse_args()
     if arguments.license:
         print(LICENSE)

--- a/tests/test-scripts/fil-interpreter.py
+++ b/tests/test-scripts/fil-interpreter.py
@@ -10,6 +10,7 @@ import os
 from ctypes import c_void_p
 import re
 from pathlib import Path
+from subprocess import check_output
 
 import pytest
 import numpy as np
@@ -214,3 +215,15 @@ def test_profiling_without_blosc_and_numexpr(tmpdir):
     finally:
         del sys.modules["blosc"]
         del sys.modules["numexpr"]
+
+def test_subprocess(tmpdir):
+    """
+    Running a subprocess doesn't blow up.
+    """
+    start_tracing(tmpdir)
+    try:
+        output = check_output(["printf", "hello"])
+    finally:
+        stop_tracing(tmpdir)
+    assert output == b"hello"
+

--- a/tests/test-scripts/fil-interpreter.py
+++ b/tests/test-scripts/fil-interpreter.py
@@ -51,7 +51,10 @@ def test_temporary_profiling(tmpdir):
     stop_tracing(tmpdir)
 
     # Allocations were tracked:
-    path = ((__file__, "f", 46), (numpy.core.numeric.__file__, "ones", ANY))
+    path = (
+        (__file__, "f", 48),
+        (numpy.core.numeric.__file__, "ones", ANY),
+    )
     allocations = get_allocations(tmpdir)
     assert match(allocations, {path: big}, as_mb) == pytest.approx(32, 0.1)
 
@@ -240,10 +243,15 @@ def test_multiprocessing(tmpdir, mode):
     Running a subprocess via multiprocessing in the various different modes
     doesn't blow up.
     """
+    # Non-tracing:
+    with multiprocessing.get_context(mode).Pool() as pool:
+        assert pool.apply((3).__add__, (4,)) == 7
+
+    # Tracing:
     start_tracing(tmpdir)
     try:
         with multiprocessing.get_context(mode).Pool() as pool:
-            assert pool.apply(return123) == 123
+            assert pool.apply((3).__add__, (4,)) == 7
     finally:
         stop_tracing(tmpdir)
         from subprocess import check_call

--- a/tests/test-scripts/fil-interpreter.py
+++ b/tests/test-scripts/fil-interpreter.py
@@ -254,6 +254,3 @@ def test_multiprocessing(tmpdir, mode):
             assert pool.apply((3).__add__, (4,)) == 7
     finally:
         stop_tracing(tmpdir)
-        from subprocess import check_call
-
-        check_call(["tree", tmpdir])

--- a/versionscript.txt
+++ b/versionscript.txt
@@ -14,5 +14,6 @@
     aligned_alloc;
     malloc_usable_size;
     pthread_create;
+    fork;
   local: *;
 };


### PR DESCRIPTION
Fixes #117.

Memory tracking in subprocesses/multiprocessing is still not supported!