### PR TITLE
Expose aligned_alloc() symbol in Conda too

### DIFF
--- a/.changelog/152.bugfix
+++ b/.changelog/152.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where aligned_alloc()-created allocations were untracked when using pip packages with Conda; specifically this is relevant to libraries written in C++.

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -439,6 +439,13 @@ SYMBOL_PREFIX(munmap)(void *addr, size_t length) {
 // match this signature, which messes up the SYMBOL_PREFIX() stuff on Linux. So,
 // we do reimplemented_aligned_alloc, the name macOS technique uses, and then
 // rely on symbol alias (see --defsym in setup.py) to fix it.
+//
+// On macOS, aligned_alloc is only in macOS 10.15 or later, we need to define
+// it.
+#ifdef __APPLE__
+void *aligned_alloc(size_t alignment, size_t size);
+#endif
+
 __attribute__((visibility("default"))) void *
 reimplemented_aligned_alloc(size_t alignment, size_t size) {
   void *result = REAL_IMPL(aligned_alloc)(alignment, size);
@@ -522,10 +529,7 @@ DYLD_INTERPOSE(SYMBOL_PREFIX(realloc), realloc)
 DYLD_INTERPOSE(SYMBOL_PREFIX(free), free)
 DYLD_INTERPOSE(SYMBOL_PREFIX(mmap), mmap)
 DYLD_INTERPOSE(SYMBOL_PREFIX(munmap), munmap)
-// Old macOS ABI that Conda uses doesn't support aligned_alloc().
-#  ifndef FIL_SKIP_ALIGNED_ALLOC
 DYLD_INTERPOSE(SYMBOL_PREFIX(aligned_alloc), aligned_alloc)
-#  endif
 DYLD_INTERPOSE(SYMBOL_PREFIX(posix_memalign), posix_memalign)
 DYLD_INTERPOSE(SYMBOL_PREFIX(pthread_create), pthread_create)
 DYLD_INTERPOSE(SYMBOL_PREFIX(fork), fork)

--- a/filprofiler/_filpreload.c
+++ b/filprofiler/_filpreload.c
@@ -435,10 +435,12 @@ SYMBOL_PREFIX(munmap)(void *addr, size_t length) {
   return result;
 }
 
-// Old glibc that conda uses doesn't support aligned_alloc()
-#ifndef FIL_SKIP_ALIGNED_ALLOC
+// Old glibc that Conda uses defines aligned_alloc() using inline that doesn't
+// match this signature, which messes up the SYMBOL_PREFIX() stuff on Linux. So,
+// we do reimplemented_aligned_alloc, the name macOS technique uses, and then
+// rely on symbol alias (see --defsym in setup.py) to fix it.
 __attribute__((visibility("default"))) void *
-SYMBOL_PREFIX(aligned_alloc)(size_t alignment, size_t size) {
+reimplemented_aligned_alloc(size_t alignment, size_t size) {
   void *result = REAL_IMPL(aligned_alloc)(alignment, size);
 
   // For now we only track anonymous mmap()s:
@@ -449,7 +451,6 @@ SYMBOL_PREFIX(aligned_alloc)(size_t alignment, size_t size) {
   }
   return result;
 }
-#endif
 
 #ifdef __linux__
 // Make sure we expose jemalloc variant of malloc_usable_size(), in case someone

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -132,9 +132,8 @@ def test_malloc_in_c_extension():
 
     # C++ aligned_alloc(); not available on Conda, where it's just a macro
     # redirecting to posix_memalign.
-    if not os.environ.get("CONDA_PREFIX"):
-        path = ((script, "<module>", 32), (script, "main", 24))
-        assert match(allocations, {path: big}, as_mb) == pytest.approx(90, 0.1)
+    path = ((script, "<module>", 32), (script, "main", 24))
+    assert match(allocations, {path: big}, as_mb) == pytest.approx(90, 0.1)
 
     # Py*_*Malloc APIs:
     path = ((script, "<module>", 32), (script, "main", 25))


### PR DESCRIPTION
Conda packages won't use aligned_alloc() on Linux, at least, but pip-installed wheels might, so worth making sure it's exposed.

Fixes #152

* [x] Test that Conda package build doesn't fail.