### PR TITLE
Fix segfault regression in 2021.7.0

### DIFF
--- a/.changelog/208.bugfix
+++ b/.changelog/208.bugfix
@@ -1,1 +1,0 @@
-Fixed segfault on some Linux versions (regression in release 2021.7.0).

--- a/.changelog/208.bugfix
+++ b/.changelog/208.bugfix
@@ -1,0 +1,1 @@
+Fixed segfault on some Linux versions (regression in release 2021.7.0).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
             deactivate
             python3.8 -m venv venv2
             . venv2/bin/activate
-            pip install -e .[dev]
+            pip install -r requirements-dev.txt
             pip install dist/*38*manylinux*.whl
             mv filprofiler filprofiler.disabled
             make test-python-no-deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,13 @@ jobs:
             set -euo pipefail
             . venv/bin/activate
             make manylinux-wheel
+            # Test wheel
+            deactivate
+            python3.8 -m venv venv2
+            . venv2/bin/activate
+            pip install dist/*3.8*manylinux*.whl
+            mv filprofiler filprofiler.disabled
+            make test-python-no-deps
       - uses: actions/upload-artifact@v2
         with:
           name: "${{ matrix.os }}-${{ matrix.python-version }}-wheel"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
             deactivate
             python3.8 -m venv venv2
             . venv2/bin/activate
-            pip install dist/*3.8*manylinux*.whl
+            pip install dist/*38*manylinux*.whl
             mv filprofiler filprofiler.disabled
             make test-python-no-deps
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,7 @@ jobs:
             deactivate
             python3.8 -m venv venv2
             . venv2/bin/activate
+            pip install -e .[dev]
             pip install dist/*38*manylinux*.whl
             mv filprofiler filprofiler.disabled
             make test-python-no-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Fil 2021.7.1 (2021-07-18)
+
+
+### Bugfixes
+
+- Fixed segfault on some Linux versions (regression in release 2021.7.0). ([#208](https://github.com/pythonspeed/filprofiler/issues/208))
+
+
 # Fil 2021.7.0 (2021-07-12)
 
 

--- a/filpreload/build.rs
+++ b/filpreload/build.rs
@@ -24,6 +24,8 @@ fn main() -> Result<(), std::io::Error> {
         println!("cargo:rustc-cdylib-link-arg=-Wl,--defsym=mmap64=fil_mmap_impl");
     };
 
+    // Compilation options are taken from CFLAGS environment variable set in
+    // setup.py based on Python's build configuration.
     cc::Build::new()
         .file("src/_filpreload.c")
         .compile("_filpreload");

--- a/wheels/build-wheels.sh
+++ b/wheels/build-wheels.sh
@@ -18,6 +18,7 @@ rm -f filprofiler/_filpreload*.dylib
 rm -rf build
 
 for PYBIN in /opt/python/cp{36,37,38,39}*/bin; do
+    touch filpreload/src/_filpreload.c  # force rebuild of Python code with new interpreter
     "${PYBIN}/pip" install -U setuptools wheel setuptools-rust
     "${PYBIN}/python" setup.py bdist_wheel -d /tmp/wheel
 done


### PR DESCRIPTION
Fixes #208 

* [x] Run tests on wheel, to catch future regressions (3.8 only for now, but at least it's catching current regression)
* [x] Actually fix the segfault