### PR TITLE
Repair builds for macOS running on Arm (M1).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ system = platform.system()
 machine = platform.machine()
 
 # Set public symbols to use for macOS. For some reason this doesn't work in
-# build.rs.
+# build.rs. Currently the exported symbols list breaks on macOS ARM for
+# unclear reasons, possibly the ABI is different (no `_` prefix to symbols maybe?)
 if platform == 'Darwin' and machine == 'x86_64':
     environ[
         "RUSTFLAGS"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ machine = platform.machine()
 # Set public symbols to use for macOS. For some reason this doesn't work in
 # build.rs. Currently the exported symbols list breaks on macOS ARM for
 # unclear reasons, possibly the ABI is different (no `_` prefix to symbols maybe?)
-if platform == 'Darwin' and machine == 'x86_64':
+if system == 'Darwin' and machine == 'x86_64':
     environ[
         "RUSTFLAGS"
     ] = f"-C link-arg=-Wl,-exported_symbols_list,{getcwd()}/filpreload/export_symbols.txt"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from os import environ, getcwd
 from os.path import join
 from glob import glob
-import sys
+import platform
 
 from setuptools import setup
 from setuptools_rust import RustExtension, Binding
@@ -18,9 +18,15 @@ def read(path):
 # Python APIs.
 environ["CFLAGS"] = CFLAGS
 
+# 'Darwin' or 'Linux'
+system = platform.system()
+
+# 'x86_64', 'arm64' (Apple M1) or 'aarch64' (AWS Graviton, Ubuntu Linux)
+machine = platform.machine()
+
 # Set public symbols to use for macOS. For some reason this doesn't work in
 # build.rs.
-if sys.platform.startswith("darwin"):
+if platform == 'Darwin' and machine == 'x86_64':
     environ[
         "RUSTFLAGS"
     ] = f"-C link-arg=-Wl,-exported_symbols_list,{getcwd()}/filpreload/export_symbols.txt"


### PR DESCRIPTION
This is a fix for the issue raised in #231 - not being able to install on Apple M1.

I had to `pip install setuptools_rust` before the project would install, but otherwise it installed successfully on Python 3.9 in a virtual environment. I can also install this branch on my 2018 Macbook Pro w/ Intel chip.

Here is the build output from the M1 Mac (macOS 11.5.2 Big Sur):

```
python setup.py install
running install
running bdist_egg
running egg_info
writing filprofiler.egg-info/PKG-INFO
writing dependency_links to filprofiler.egg-info/dependency_links.txt
writing entry points to filprofiler.egg-info/entry_points.txt
writing requirements to filprofiler.egg-info/requires.txt
writing top-level names to filprofiler.egg-info/top_level.txt
adding license file 'LICENSE'
writing manifest file 'filprofiler.egg-info/SOURCES.txt'
installing library code to build/bdist.macosx-11.5-arm64/egg
running install_lib
running build_py
copying filprofiler/_version.py -> build/lib.macosx-11.5-arm64-3.9/filprofiler
running build_ext
running build_rust
cargo rustc --lib --manifest-path filpreload/Cargo.toml --features pyo3/extension-module --release --verbose -- --crate-type cdylib -C link-arg=-undefined -C link-arg=dynamic_lookup
       Fresh cfg-if v1.0.0
       Fresh version_check v0.9.3
       Fresh unicode-xid v0.2.2
       Fresh cc v1.0.70
       Fresh autocfg v1.0.1
       Fresh once_cell v1.8.0
       Fresh smallvec v1.6.1
       Fresh nodrop v0.1.14
       Fresh scopeguard v1.1.0
       Fresh void v1.0.2
       Fresh rand_core v0.5.1
       Fresh bytemuck v1.7.2
       Fresh cfg-if v0.1.10
       Fresh gimli v0.25.0
       Fresh adler v1.0.2
       Fresh itoa v0.4.8
       Fresh str_stack v0.1.0
       Fresh rustc-demangle v0.1.21
       Fresh either v1.6.1
       Fresh lazy_static v1.4.0
   Compiling pyo3-build-config v0.14.5
       Fresh instant v0.1.10
     Running `/Users/michael/Code/filprofiler/target/release/build/pyo3-build-config-26251cd714da05c3/build-script-build`
       Fresh libloading v0.7.0
warning: unused variable: `cur_dir`
 --> filpreload/build.rs:3:9
  |
3 |     let cur_dir = std::env::current_dir()?;
  |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_cur_dir`
  |
  = note: `#[warn(unused_variables)]` on by default

       Fresh lock_api v0.4.5
       Fresh rgb v0.8.27
       Fresh rand_xoshiro v0.4.0
warning: `filpreload` (build script) generated 1 warning
       Fresh addr2line v0.16.0
       Fresh itertools v0.10.1
       Fresh libc v0.2.101
       Fresh proc-macro2 v1.0.29
       Fresh memchr v2.4.1
       Fresh typenum v1.14.0
       Fresh bitflags v1.2.1
       Fresh arrayvec v0.4.12
       Fresh log v0.4.14
warning: src/_filpreload.c:76:10: warning: cast to smaller integer type 'int' from 'void * _Nullable' [-Wvoid-pointer-to-int-cast]
warning:   return (int)pthread_getspecific(will_i_be_reentrant);
warning:          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: src/_filpreload.c:80:17: warning: cast to smaller integer type 'int' from 'void * _Nullable' [-Wvoid-pointer-to-int-cast]
warning:   int current = (int) pthread_getspecific(will_i_be_reentrant);
warning:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: src/_filpreload.c:81:44: warning: cast to 'void *' from smaller integer type 'int' [-Wint-to-void-pointer-cast]
warning:   pthread_setspecific(will_i_be_reentrant, (void *)(current + 1));
warning:                                            ^~~~~~~~~~~~~~~~~~~~~
warning: src/_filpreload.c:85:17: warning: cast to smaller integer type 'int' from 'void * _Nullable' [-Wvoid-pointer-to-int-cast]
warning:   int current = (int)pthread_getspecific(will_i_be_reentrant);
warning:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: src/_filpreload.c:86:44: warning: cast to 'void *' from smaller integer type 'int' [-Wint-to-void-pointer-cast]
warning:   pthread_setspecific(will_i_be_reentrant, (void *)(current - 1));
warning:                                            ^~~~~~~~~~~~~~~~~~~~~
warning: 5 warnings generated.
       Fresh quote v1.0.9
       Fresh getrandom v0.2.3
       Fresh parking_lot_core v0.8.5
       Fresh bitmaps v2.1.0
       Fresh darwin-libproc-sys v0.1.2
       Fresh object v0.26.2
       Fresh quick-xml v0.22.0
       Fresh mach v0.3.2
       Fresh atty v0.2.14
       Fresh miniz_oxide v0.4.4
       Fresh num-format v0.4.0
       Fresh nix v0.17.0
       Fresh syn v1.0.76
       Fresh parking_lot v0.11.2
       Fresh darwin-libproc v0.1.2
       Fresh sized-chunks v0.6.5
       Fresh ahash v0.7.4
       Fresh thiserror-impl v1.0.29
       Fresh derivative v2.2.0
       Fresh backtrace v0.3.61
       Fresh thiserror v1.0.29
       Fresh im v15.0.0
       Fresh inferno v0.10.7
       Fresh psutil v3.2.1
     Running `rustc --crate-name pyo3_build_config --edition=2018 /Users/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/pyo3-build-config-0.14.5/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' --cfg 'feature="resolve-config"' -C metadata=0d4d2912a831b157 -C extra-filename=-0d4d2912a831b157 --out-dir /Users/michael/Code/filprofiler/target/release/deps -L dependency=/Users/michael/Code/filprofiler/target/release/deps --extern once_cell=/Users/michael/Code/filprofiler/target/release/deps/libonce_cell-98b94f546c1a8a4a.rmeta --cap-lints allow -C 'link-args=-Wl,-install_name,@rpath/_filpreload.cpython-39-darwin.so'`
   Compiling pyo3 v0.14.5
     Running `rustc --crate-name build_script_build --edition=2018 /Users/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/pyo3-0.14.5/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="extension-module"' -C metadata=dd1efe6ae634d9b8 -C extra-filename=-dd1efe6ae634d9b8 --out-dir /Users/michael/Code/filprofiler/target/release/build/pyo3-dd1efe6ae634d9b8 -L dependency=/Users/michael/Code/filprofiler/target/release/deps --extern pyo3_build_config=/Users/michael/Code/filprofiler/target/release/deps/libpyo3_build_config-0d4d2912a831b157.rlib --cap-lints allow -C 'link-args=-Wl,-install_name,@rpath/_filpreload.cpython-39-darwin.so'`
     Running `/Users/michael/Code/filprofiler/target/release/build/pyo3-dd1efe6ae634d9b8/build-script-build`
     Running `rustc --crate-name pyo3 --edition=2018 /Users/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/pyo3-0.14.5/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C linker-plugin-lto --cfg 'feature="extension-module"' -C metadata=8bc715376be679dc -C extra-filename=-8bc715376be679dc --out-dir /Users/michael/Code/filprofiler/target/release/deps -L dependency=/Users/michael/Code/filprofiler/target/release/deps --extern cfg_if=/Users/michael/Code/filprofiler/target/release/deps/libcfg_if-f8c5e30e30bcf795.rmeta --extern libc=/Users/michael/Code/filprofiler/target/release/deps/liblibc-d16bd64d4728f4c5.rmeta --extern parking_lot=/Users/michael/Code/filprofiler/target/release/deps/libparking_lot-7ad919608f5211e9.rmeta --cap-lints allow -C 'link-args=-Wl,-install_name,@rpath/_filpreload.cpython-39-darwin.so' --cfg Py_3_6 --cfg Py_3_7 --cfg Py_3_8 --cfg Py_3_9 --cfg 'py_sys_config="WITH_THREAD"' --cfg min_const_generics --cfg addr_of`
   Compiling pymemprofile_api v0.1.0 (/Users/michael/Code/filprofiler/memapi)
     Running `rustc --crate-name pymemprofile_api --edition=2018 memapi/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C linker-plugin-lto --cfg 'feature="default"' -C metadata=67364054fdd4af0b -C extra-filename=-67364054fdd4af0b --out-dir /Users/michael/Code/filprofiler/target/release/deps -L dependency=/Users/michael/Code/filprofiler/target/release/deps --extern ahash=/Users/michael/Code/filprofiler/target/release/deps/libahash-ea0eda600af0e6a8.rmeta --extern backtrace=/Users/michael/Code/filprofiler/target/release/deps/libbacktrace-e6f0f7beb0fa01ce.rmeta --extern derivative=/Users/michael/Code/filprofiler/target/release/deps/libderivative-f32db7fa3b45e022.dylib --extern im=/Users/michael/Code/filprofiler/target/release/deps/libim-ef1de85065ea2548.rmeta --extern inferno=/Users/michael/Code/filprofiler/target/release/deps/libinferno-614c36ac19cbf6e7.rmeta --extern itertools=/Users/michael/Code/filprofiler/target/release/deps/libitertools-4888f0bab3f56de6.rmeta --extern lazy_static=/Users/michael/Code/filprofiler/target/release/deps/liblazy_static-191cc879bea2623b.rmeta --extern libc=/Users/michael/Code/filprofiler/target/release/deps/liblibc-d16bd64d4728f4c5.rmeta --extern libloading=/Users/michael/Code/filprofiler/target/release/deps/liblibloading-24b2665c0b02203f.rmeta --extern once_cell=/Users/michael/Code/filprofiler/target/release/deps/libonce_cell-56011395edd8377c.rmeta --extern psutil=/Users/michael/Code/filprofiler/target/release/deps/libpsutil-f360e29d96dcf047.rmeta --extern pyo3=/Users/michael/Code/filprofiler/target/release/deps/libpyo3-8bc715376be679dc.rmeta -C 'link-args=-Wl,-install_name,@rpath/_filpreload.cpython-39-darwin.so'`
warning: unused imports: `Library`, `Symbol`
 --> memapi/src/ffi.rs:7:28
  |
7 | use libloading::os::unix::{Library, Symbol};
  |                            ^^^^^^^  ^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::fs::read_to_string`
 --> memapi/src/oom.rs:1:5
  |
1 | use std::fs::read_to_string;
  |     ^^^^^^^^^^^^^^^^^^^^^^^

warning: `pymemprofile_api` (lib) generated 2 warnings
   Compiling filpreload v0.1.0 (/Users/michael/Code/filprofiler/filpreload)
     Running `rustc --crate-name filpreload --edition=2018 filpreload/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type cdylib --emit=dep-info,link -C opt-level=3 -C lto --crate-type cdylib -C link-arg=-undefined -C link-arg=dynamic_lookup --cfg 'feature="default"' --cfg 'feature="extension-module"' -C metadata=e35f7712556e7ef0 --out-dir /Users/michael/Code/filprofiler/target/release/deps -L dependency=/Users/michael/Code/filprofiler/target/release/deps --extern lazy_static=/Users/michael/Code/filprofiler/target/release/deps/liblazy_static-191cc879bea2623b.rlib --extern parking_lot=/Users/michael/Code/filprofiler/target/release/deps/libparking_lot-7ad919608f5211e9.rlib --extern pymemprofile_api=/Users/michael/Code/filprofiler/target/release/deps/libpymemprofile_api-67364054fdd4af0b.rlib --extern pyo3=/Users/michael/Code/filprofiler/target/release/deps/libpyo3-8bc715376be679dc.rlib -C 'link-args=-Wl,-install_name,@rpath/_filpreload.cpython-39-darwin.so' -L native=/Users/michael/Code/filprofiler/target/release/build/filpreload-7f3e57b04d72f6ff/out -l static=_filpreload`
    Finished release [optimized] target(s) in 11.78s
creating build/bdist.macosx-11.5-arm64/egg
creating build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_report.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_tracer.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_script.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_version.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_cachegrind.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/__init__.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_filpreload.cpython-39-darwin.so -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/api.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_ipython.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_testing.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/licenses.txt -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/__main__.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
copying build/lib.macosx-11.5-arm64-3.9/filprofiler/_utils.py -> build/bdist.macosx-11.5-arm64/egg/filprofiler
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/_report.py to _report.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/_tracer.py to _tracer.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/_script.py to _script.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/_version.py to _version.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/_cachegrind.py to _cachegrind.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/__init__.py to __init__.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/api.py to api.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/_ipython.py to _ipython.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/_testing.py to _testing.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/__main__.py to __main__.cpython-39.pyc
byte-compiling build/bdist.macosx-11.5-arm64/egg/filprofiler/_utils.py to _utils.cpython-39.pyc
installing package data to build/bdist.macosx-11.5-arm64/egg
running install_data
creating build/bdist.macosx-11.5-arm64/egg/share
creating build/bdist.macosx-11.5-arm64/egg/share/jupyter
creating build/bdist.macosx-11.5-arm64/egg/share/jupyter/kernels
creating build/bdist.macosx-11.5-arm64/egg/share/jupyter/kernels/filprofile
copying data_kernelspec/kernel.json -> build/bdist.macosx-11.5-arm64/egg/share/jupyter/kernels/filprofile
copying data_kernelspec/logo-64x64.png -> build/bdist.macosx-11.5-arm64/egg/share/jupyter/kernels/filprofile
copying data_kernelspec/logo-32x32.png -> build/bdist.macosx-11.5-arm64/egg/share/jupyter/kernels/filprofile
creating build/bdist.macosx-11.5-arm64/egg/EGG-INFO
copying filprofiler.egg-info/PKG-INFO -> build/bdist.macosx-11.5-arm64/egg/EGG-INFO
copying filprofiler.egg-info/SOURCES.txt -> build/bdist.macosx-11.5-arm64/egg/EGG-INFO
copying filprofiler.egg-info/dependency_links.txt -> build/bdist.macosx-11.5-arm64/egg/EGG-INFO
copying filprofiler.egg-info/entry_points.txt -> build/bdist.macosx-11.5-arm64/egg/EGG-INFO
copying filprofiler.egg-info/requires.txt -> build/bdist.macosx-11.5-arm64/egg/EGG-INFO
copying filprofiler.egg-info/top_level.txt -> build/bdist.macosx-11.5-arm64/egg/EGG-INFO
writing build/bdist.macosx-11.5-arm64/egg/EGG-INFO/native_libs.txt
zip_safe flag not set; analyzing archive contents...
filprofiler.__pycache__._script.cpython-39: module references __file__
creating 'dist/filprofiler-2021.8.1.dev50+ge0fe8de-py3.9-macosx-11.5-arm64.egg' and adding 'build/bdist.macosx-11.5-arm64/egg' to it
removing 'build/bdist.macosx-11.5-arm64/egg' (and everything under it)
Processing filprofiler-2021.8.1.dev50+ge0fe8de-py3.9-macosx-11.5-arm64.egg
creating /Users/michael/.pyenv/versions/3.9.6/envs/t3-3.9.6/lib/python3.9/site-packages/filprofiler-2021.8.1.dev50+ge0fe8de-py3.9-macosx-11.5-arm64.egg
Extracting filprofiler-2021.8.1.dev50+ge0fe8de-py3.9-macosx-11.5-arm64.egg to /Users/michael/.pyenv/versions/3.9.6/envs/t3-3.9.6/lib/python3.9/site-packages
Adding filprofiler 2021.8.1.dev50+ge0fe8de to easy-install.pth file
Installing fil-profile script to /Users/michael/.pyenv/versions/t3-3.9.6/bin

Installed /Users/michael/.pyenv/versions/3.9.6/envs/t3-3.9.6/lib/python3.9/site-packages/filprofiler-2021.8.1.dev50+ge0fe8de-py3.9-macosx-11.5-arm64.egg
Processing dependencies for filprofiler==2021.8.1.dev50+ge0fe8de
Searching for threadpoolctl==2.2.0
Best match: threadpoolctl 2.2.0
Adding threadpoolctl 2.2.0 to easy-install.pth file

Using /Users/michael/.pyenv/versions/3.9.6/envs/t3-3.9.6/lib/python3.9/site-packages
Finished processing dependencies for filprofiler==2021.8.1.dev50+ge0fe8de
```

