### PR TITLE
Update message on --no-browser

### DIFF
--- a/filprofiler/_script.py
+++ b/filprofiler/_script.py
@@ -257,8 +257,10 @@ def stage_2():
             os.path.join(arguments.output_path, timestamp_now())
         ),
     )
+    msg_browser = ", and opened automatically in a browser" if not arguments.no_browser else ", and stored in {}.".format(arguments.output_path)
+    msg_fil_plan = "=fil-profile= Memory usage will be written out at exit{}.\n".format(msg_browser)
     print(
-        "=fil-profile= Memory usage will be written out at exit, and opened automatically in a browser.\n"
+        msg_fil_plan,
         "=fil-profile= You can also run the following command while the program is still running to write out peak memory usage up to that point: "
         "kill -s SIGUSR2 {}".format(getpid()),
         file=sys.stderr,

--- a/filprofiler/_script.py
+++ b/filprofiler/_script.py
@@ -257,7 +257,7 @@ def stage_2():
             os.path.join(arguments.output_path, timestamp_now())
         ),
     )
-     
+
     msg_browser = ", and opened automatically in a browser" if not arguments.no_browser else ", and stored in {}.".format(arguments.output_path)
     msg_fil_plan = "=fil-profile= Memory usage will be written out at exit{}.\n".format(msg_browser)
     print(

--- a/filprofiler/_script.py
+++ b/filprofiler/_script.py
@@ -260,8 +260,8 @@ def stage_2():
     msg_browser = ", and opened automatically in a browser" if not arguments.no_browser else ", and stored in {}.".format(arguments.output_path)
     msg_fil_plan = "=fil-profile= Memory usage will be written out at exit{}.\n".format(msg_browser)
     print(
-        msg_fil_plan,
-        "=fil-profile= You can also run the following command while the program is still running to write out peak memory usage up to that point: "
+        msg_fil_plan +
+        "=fil-profile= You can also run the following command while the program is still running to write out peak memory usage up to that point: " +
         "kill -s SIGUSR2 {}".format(getpid()),
         file=sys.stderr,
     )

--- a/filprofiler/_script.py
+++ b/filprofiler/_script.py
@@ -257,6 +257,7 @@ def stage_2():
             os.path.join(arguments.output_path, timestamp_now())
         ),
     )
+     
     msg_browser = ", and opened automatically in a browser" if not arguments.no_browser else ", and stored in {}.".format(arguments.output_path)
     msg_fil_plan = "=fil-profile= Memory usage will be written out at exit{}.\n".format(msg_browser)
     print(


### PR DESCRIPTION
Fixes #347 by changing the message depending on the status of the `--no-browser` argument.

- Default:
> =fil-profile= Memory usage will be written out at exit, and opened automatically in a browser.

- When `--no-browser` is set:
> =fil-profile= Memory usage will be written out at exit, and stored in fil-result.