### PR TITLE
Workaround for slow flamegraph rendering

### DIFF
--- a/.changelog/390.bugfix
+++ b/.changelog/390.bugfix
@@ -1,0 +1,1 @@
+Speed up rendering of flamegraphs in cases where there are many smaller allocations, by filtering out allocations smaller than 0.2% of total memory. Future releases may re-enable showing smaller allocations if a better fix can be found.

--- a/memapi/src/flamegraph.rs
+++ b/memapi/src/flamegraph.rs
@@ -135,6 +135,7 @@ pub fn get_flamegraph<I: IntoIterator<Item = String>>(
     options.reverse_stack_order = reversed;
     options.color_diffusion = true;
     options.direction = flamegraph::Direction::Inverted;
+    options.min_width = 0.2;
     // Maybe disable this some day; but for now it makes debugging much
     // easier:
     options.pretty_xml = true;


### PR DESCRIPTION
Doesn't fix #390, but makes it better at least.